### PR TITLE
strip ansi codes when not running in a terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .changelog_generator.toml
+mutants.out*

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,8 +1,8 @@
 [tasks.test]
 # this needs the crates 'nextest' and 'cargo-llvm-cov' installed locally
 command = "cargo"
-args = ["llvm-cov", "nextest"]
+args = ["llvm-cov", "nextest", "--no-fail-fast"]
 
 [tasks.test-html]
 command = "cargo"
-args = ["llvm-cov", "nextest", "--html"]
+args = ["llvm-cov", "nextest", "--no-fail-fast", "--html"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Documentation](https://docs.rs/colored_text/badge.svg)](https://docs.rs/colored_text)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A simple and intuitive library for adding colors and styles to terminal text in Rust.
+A simple and intuitive library for adding colors and styles to terminal text in
+Rust.
 
 ## Features
 
@@ -17,6 +18,8 @@ A simple and intuitive library for adding colors and styles to terminal text in 
 - Zero dependencies
 - Supports the `NO_COLOR` environment variable - if this is set, all colors are
   disabled and the text is returned uncolored
+- Detects if the output is NOT going to a terminal (e.g. is going to a file or a
+  pipe) and disables colors if so (this check can also be disabled)
 - Complete documentation and examples
 
 ## Installation
@@ -107,11 +110,15 @@ println!("{}", format!("Hello, {}!", name.blue().bold()));
 
 ### RGB, HSL, and Hex Colors
 
-- `.rgb(r, g, b)` - Custom text color using RGB values (0-255, compile-time enforced)
-- `.on_rgb(r, g, b)` - Custom background color using RGB values (0-255, compile-time enforced)
-- `.hsl(h, s, l)` - Custom text color using HSL values (hue: 0-360°, saturation: 0-100%, lightness: 0-100%)
+- `.rgb(r, g, b)` - Custom text color using RGB values (0-255, compile-time
+  enforced)
+- `.on_rgb(r, g, b)` - Custom background color using RGB values (0-255,
+  compile-time enforced)
+- `.hsl(h, s, l)` - Custom text color using HSL values (hue: 0-360°, saturation:
+  0-100%, lightness: 0-100%)
 - `.on_hsl(h, s, l)` - Custom background color using HSL values
-- `.hex(code)` - Custom text color using HTML/CSS hex code (e.g., "#ff8000" or "ff8000")
+- `.hex(code)` - Custom text color using HTML/CSS hex code (e.g., "#ff8000" or
+  "ff8000")
 - `.on_hex(code)` - Custom background color using HTML/CSS hex code
 
 ### Other
@@ -123,7 +130,8 @@ println!("{}", format!("Hello, {}!", name.blue().bold()));
 - RGB values must be in range 0-255 (enforced at compile time via `u8` type)
 - Attempting to use RGB values > 255 will result in a compile error
 - Hex color codes can be provided with or without the '#' prefix
-- Invalid hex codes (wrong length, invalid characters) will result in uncolored text
+- Invalid hex codes (wrong length, invalid characters) will result in uncolored
+  text
 - All color methods are guaranteed to return a valid string, never panicking
 
 ```rust
@@ -147,7 +155,10 @@ println!("{}", "Too short".hex("#f8")); // Returns uncolored text
 
 ## NO_COLOR Support
 
-This library respects the [NO_COLOR](https://no-color.org/) environment variable. If `NO_COLOR` is set (to any value), all color and style methods will return plain unformatted text. This makes it easy to disable all colors globally if needed.
+This library respects the [NO_COLOR](https://no-color.org/) environment
+variable. If `NO_COLOR` is set (to any value), all color and style methods will
+return plain unformatted text. This makes it easy to disable all colors globally
+if needed.
 
 ```rust
 // Colors enabled (NO_COLOR not set)
@@ -160,7 +171,9 @@ println!("{}", "Red text".red()); // Prints without color
 
 ## Terminal Detection Configuration
 
-By default, this library checks if the output is going to a terminal and disables colors when it's not (e.g., when piping output to a file). This behavior can be controlled using `ColorizeConfig`:
+By default, this library checks if the output is going to a terminal and
+disables colors when it's not (e.g., when piping output to a file). This
+behavior can be controlled using `ColorizeConfig`:
 
 ```rust
 use colored_text::{Colorize, ColorizeConfig};
@@ -174,16 +187,24 @@ ColorizeConfig::set_terminal_check(true);
 println!("{}", "Only colored in terminal".red());
 ```
 
-This is particularly useful in test environments where you might want to force-enable colors regardless of the terminal status. The configuration is thread-local, making it safe to use in parallel tests without affecting other threads.
+This is particularly useful in test environments where you might want to
+force-enable colors regardless of the terminal status. The configuration is
+thread-local, making it safe to use in parallel tests without affecting other
+threads.
 
-Note: Even when terminal detection is disabled, the `NO_COLOR` environment variable still takes precedence - if it's set, colors will be disabled regardless of this setting.
+Note: Even when terminal detection is disabled, the `NO_COLOR` environment
+variable still takes precedence - if it's set, colors will be disabled
+regardless of this setting.
 
 ## Terminal Compatibility
 
-This library uses ANSI escape codes for coloring and styling text. Most modern terminals support these codes, but the actual appearance may vary depending on your terminal emulator and its configuration:
+This library uses ANSI escape codes for coloring and styling text. Most modern
+terminals support these codes, but the actual appearance may vary depending on
+your terminal emulator and its configuration:
 
 - Basic colors (codes 30-37) are widely supported
-- Bright colors (codes 90-97) may appear the same as basic colors in some terminals
+- Bright colors (codes 90-97) may appear the same as basic colors in some
+  terminals
 - RGB colors require true color support in your terminal
 - Some styling options (like italic) might not work in all terminals
 
@@ -193,7 +214,8 @@ Check out the [examples](examples/) directory for more usage examples.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
+for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,26 @@ std::env::set_var("NO_COLOR", "1");
 println!("{}", "Red text".red()); // Prints without color
 ```
 
+## Terminal Detection Configuration
+
+By default, this library checks if the output is going to a terminal and disables colors when it's not (e.g., when piping output to a file). This behavior can be controlled using `ColorizeConfig`:
+
+```rust
+use colored_text::{Colorize, ColorizeConfig};
+
+// Disable terminal detection (colors will be enabled regardless of terminal status)
+ColorizeConfig::set_terminal_check(false);
+println!("{}", "Always colored".red());
+
+// Re-enable terminal detection (default behavior)
+ColorizeConfig::set_terminal_check(true);
+println!("{}", "Only colored in terminal".red());
+```
+
+This is particularly useful in test environments where you might want to force-enable colors regardless of the terminal status. The configuration is thread-local, making it safe to use in parallel tests without affecting other threads.
+
+Note: Even when terminal detection is disabled, the `NO_COLOR` environment variable still takes precedence - if it's set, colors will be disabled regardless of this setting.
+
 ## Terminal Compatibility
 
 This library uses ANSI escape codes for coloring and styling text. Most modern terminals support these codes, but the actual appearance may vary depending on your terminal emulator and its configuration:

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -78,4 +78,10 @@ fn main() {
         "is".green(),
         "important".yellow().underline()
     );
+
+    // Disabling colors
+    println!("\nDisabling colors by setting NO_COLOR environment variable:");
+    std::env::set_var("NO_COLOR", "1");
+    println!("{}", "This text should have no color".red().bold());
+    std::env::remove_var("NO_COLOR");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,43 +170,76 @@ fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
 /// It can be used with both string literals and owned strings.
 pub trait Colorize {
     /// Returns a colored version of the string
+    /// Internal method to apply ANSI color codes to text.
+    /// This is used by all other coloring methods.
     fn colorize(&self, color_code: &str) -> String;
 
     // Basic colors
+    /// Colors the text red using ANSI escape codes.
     fn red(&self) -> String;
+    /// Colors the text green using ANSI escape codes.
     fn green(&self) -> String;
+    /// Colors the text yellow using ANSI escape codes.
     fn yellow(&self) -> String;
+    /// Colors the text blue using ANSI escape codes.
     fn blue(&self) -> String;
+    /// Colors the text magenta using ANSI escape codes.
     fn magenta(&self) -> String;
+    /// Colors the text cyan using ANSI escape codes.
     fn cyan(&self) -> String;
+    /// Colors the text white using ANSI escape codes.
     fn white(&self) -> String;
+    /// Colors the text black using ANSI escape codes.
     fn black(&self) -> String;
 
     // Bright colors
+    /// Colors the text bright red using ANSI escape codes.
     fn bright_red(&self) -> String;
+    /// Colors the text bright green using ANSI escape codes.
     fn bright_green(&self) -> String;
+    /// Colors the text bright yellow using ANSI escape codes.
     fn bright_yellow(&self) -> String;
+    /// Colors the text bright blue using ANSI escape codes.
     fn bright_blue(&self) -> String;
+    /// Colors the text bright magenta using ANSI escape codes.
     fn bright_magenta(&self) -> String;
+    /// Colors the text bright cyan using ANSI escape codes.
     fn bright_cyan(&self) -> String;
+    /// Colors the text bright white using ANSI escape codes.
     fn bright_white(&self) -> String;
 
     // Styles
+    /// Makes the text bold using ANSI escape codes.
     fn bold(&self) -> String;
+    /// Makes the text dimmed using ANSI escape codes.
     fn dim(&self) -> String;
+    /// Makes the text italic using ANSI escape codes.
+    /// Note: Not all terminals support italic text.
     fn italic(&self) -> String;
+    /// Underlines the text using ANSI escape codes.
     fn underline(&self) -> String;
+    /// Inverts the text and background colors using ANSI escape codes.
     fn inverse(&self) -> String;
+    /// Adds a strikethrough to the text using ANSI escape codes.
+    /// Note: Not all terminals support strikethrough.
     fn strikethrough(&self) -> String;
 
     // Background colors
+    /// Sets the background color to red using ANSI escape codes.
     fn on_red(&self) -> String;
+    /// Sets the background color to green using ANSI escape codes.
     fn on_green(&self) -> String;
+    /// Sets the background color to yellow using ANSI escape codes.
     fn on_yellow(&self) -> String;
+    /// Sets the background color to blue using ANSI escape codes.
     fn on_blue(&self) -> String;
+    /// Sets the background color to magenta using ANSI escape codes.
     fn on_magenta(&self) -> String;
+    /// Sets the background color to cyan using ANSI escape codes.
     fn on_cyan(&self) -> String;
+    /// Sets the background color to white using ANSI escape codes.
     fn on_white(&self) -> String;
+    /// Sets the background color to black using ANSI escape codes.
     fn on_black(&self) -> String;
 
     // RGB, HSL, and Hex color support
@@ -218,10 +251,14 @@ pub trait Colorize {
     fn hsl(&self, h: f32, s: f32, l: f32) -> String;
     /// Set background color using HSL values (hue: 0-360, saturation: 0-100, lightness: 0-100)
     fn on_hsl(&self, h: f32, s: f32, l: f32) -> String;
+    /// Set text color using hex code (e.g., "#ff8000" or "ff8000").
+    /// Returns uncolored text if the hex code is invalid.
     fn hex(&self, hex: &str) -> String;
+    /// Set background color using hex code (e.g., "#ff8000" or "ff8000").
+    /// Returns uncolored text if the hex code is invalid.
     fn on_hex(&self, hex: &str) -> String;
 
-    // Clear all formatting
+    /// Removes all color and style formatting from the text.
     fn clear(&self) -> String;
 }
 


### PR DESCRIPTION
This will detect if the output is not a terminal (eg pipe or to file) and in that case strip the ansi codes.

Also add a config structure with a flag to disable the terminal test, so that CI and some other test runners wont fail (`nextest` for example. `tarpaulin` still fails for some reason though).

I havn't really found a way to **TEST** the terminal detection though yet, so it is just tested manually.