### PR TITLE
Correct the install section version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-colored_text = "0.3.0"
+colored_text = "0.4.1"
 ```
 
 ## Usage


### PR DESCRIPTION
The release 0.4.0 README still mentioned version `0.3.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency information in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->